### PR TITLE
Add `resizeObserverEntry` as a parameter to  `evaluate()`

### DIFF
--- a/dist/cdn.js
+++ b/dist/cdn.js
@@ -4,7 +4,8 @@
     Alpine.directive("resize", (el, {expression}, {evaluateLater, cleanup}) => {
       const evaluate = evaluateLater(expression);
       const observer = new ResizeObserver((entries) => {
-        entries.forEach((entry) => evaluate());
+        entries.forEach((entry) => evaluate(() => {
+        }, {params: [entry]}));
       });
       observer.observe(el);
       cleanup(() => {

--- a/dist/cdn.min.js
+++ b/dist/cdn.min.js
@@ -1,1 +1,1 @@
-(()=>{function n(i){i.directive("resize",(r,{expression:t},{evaluateLater:o,cleanup:s})=>{let c=o(t),e=new ResizeObserver(d=>{d.forEach(a=>c())});e.observe(r),s(()=>{e.disconnect()})})}document.addEventListener("alpine:init",()=>{window.Alpine.plugin(n)});})();
+(()=>{function i(n){n.directive("resize",(r,{expression:s},{evaluateLater:t,cleanup:o})=>{let c=t(s),e=new ResizeObserver(a=>{a.forEach(d=>c(()=>{},{params:[d]}))});e.observe(r),o(()=>{e.disconnect()})})}document.addEventListener("alpine:init",()=>{window.Alpine.plugin(i)});})();

--- a/dist/module.cjs.js
+++ b/dist/module.cjs.js
@@ -16,7 +16,8 @@ function src_default(Alpine) {
   Alpine.directive("resize", (el, {expression}, {evaluateLater, cleanup}) => {
     const evaluate = evaluateLater(expression);
     const observer = new ResizeObserver((entries) => {
-      entries.forEach((entry) => evaluate());
+      entries.forEach((entry) => evaluate(() => {
+      }, {params: [entry]}));
     });
     observer.observe(el);
     cleanup(() => {

--- a/dist/module.esm.js
+++ b/dist/module.esm.js
@@ -3,7 +3,8 @@ function src_default(Alpine) {
   Alpine.directive("resize", (el, {expression}, {evaluateLater, cleanup}) => {
     const evaluate = evaluateLater(expression);
     const observer = new ResizeObserver((entries) => {
-      entries.forEach((entry) => evaluate());
+      entries.forEach((entry) => evaluate(() => {
+      }, {params: [entry]}));
     });
     observer.observe(el);
     cleanup(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 export default function (Alpine) {
     Alpine.directive(
         'resize', (el, { expression }, { evaluateLater, cleanup }) => {
-            console.log(expression);
             const evaluate = evaluateLater(expression)
 
             const observer = new ResizeObserver(entries => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,11 @@
 export default function (Alpine) {
     Alpine.directive(
         'resize', (el, { expression }, { evaluateLater, cleanup }) => {
+            console.log(expression);
             const evaluate = evaluateLater(expression)
 
             const observer = new ResizeObserver(entries => {
-                entries.forEach(entry => evaluate())
+                entries.forEach(entry => evaluate(() => {}, { params: [entry] }))
             })
 
             observer.observe(el)


### PR DESCRIPTION
Hi there, nice directive!

I have quite a few use cases where I need to know the actual dimensions of a resized element. Right now, I need re-query the DOM for `this.$root.clientWidth` and/or `this.$root.clientHeight`. 

A better solution would be to pass the `ResizeObserverEntry` reference directly to the `evaluate` callback. I had a look at how Alpinejs is doing this in [`x-on`](https://github.com/alpinejs/alpine/blob/main/packages/alpinejs/src/directives/x-on.js#L18) and implemented the same logic for `x-resize`. Now I can easily access the entry like this:

```html
<div x-data x-resize="(resizeObserverEntry) => console.log(resizeObserverEntry);"></div>
```

What do you think?